### PR TITLE
Apply a quick-and-dirty hack to Allow used as drop in replacement for instant.io 

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
     client.on('no-peers', params => console.error('Player couldnt find any peers!', params))
     if(window.location.hash) {
       var hash = window.location.hash.substring(1); //Puts hash in variable, and removes the # character
-      alert(hash);
+      //alert(hash);
       client.playTorrent('magnet:?xt=urn:btih:'+ hash + '&tr=wss%3A%2F%2Ftracker.openwebtorrent.com');
       // hash found
     } else {

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
     if(window.location.hash) {
       var hash = window.location.hash.substring(1); //Puts hash in variable, and removes the # character
       alert (hash);
-      client.playTorrent('magnet:?xt=urn:btih:'+ hash +"&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F")
+      client.playTorrent('magnet:?xt=urn:btih:'+ hash + '&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F')
       // hash found
     } else {
       // No hash found

--- a/index.html
+++ b/index.html
@@ -155,7 +155,14 @@
     client.on('offline-torrent', params => console.log('Player loaded an offline stored torrent!', params))
     client.on('no-files', params => console.error('Player couldnt find any playable video files!', params))
     client.on('no-peers', params => console.error('Player couldnt find any peers!', params))
-
+    if(window.location.hash) {
+      var hash = window.location.hash.substring(1); //Puts hash in variable, and removes the # character
+      alert (hash);
+      client.playTorrent('magnet:?xt=urn:btih:'+ hash +"&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F")
+      // hash found
+    } else {
+      // No hash found
+    }
     function d(a) {
       switch (a) {
         case 1:

--- a/index.html
+++ b/index.html
@@ -158,7 +158,9 @@
     if(window.location.hash) {
       var hash = window.location.hash.substring(1); //Puts hash in variable, and removes the # character
       //alert(hash);
-      client.playTorrent('magnet:?xt=urn:btih:'+ hash + '&tr=wss%3A%2F%2Ftracker.openwebtorrent.com');
+      if hash.length == 40 {
+        client.playTorrent('magnet:?xt=urn:btih:'+ hash + '&tr=wss%3A%2F%2Ftracker.openwebtorrent.com');
+      }
       // hash found
     } else {
       // No hash found

--- a/index.html
+++ b/index.html
@@ -157,8 +157,8 @@
     client.on('no-peers', params => console.error('Player couldnt find any peers!', params))
     if(window.location.hash) {
       var hash = window.location.hash.substring(1); //Puts hash in variable, and removes the # character
-      alert (hash);
-      client.playTorrent('magnet:?xt=urn:btih:'+ hash + '&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F')
+      alert(hash);
+      client.playTorrent('magnet:?xt=urn:btih:'+ hash + '&tr=wss%3A%2F%2Ftracker.openwebtorrent.com');
       // hash found
     } else {
       // No hash found

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
     if(window.location.hash) {
       var hash = window.location.hash.substring(1); //Puts hash in variable, and removes the # character
       //alert(hash);
-      if hash.length == 40 {
+      if (hash.length == 40) {
         client.playTorrent('magnet:?xt=urn:btih:'+ hash + '&tr=wss%3A%2F%2Ftracker.openwebtorrent.com');
       }
       // hash found


### PR DESCRIPTION
Relatively simple 10 lines of code
Allows you to append an info hash to the end of the URL in the same manner as instant.io